### PR TITLE
Patch Invalid "Host" Header

### DIFF
--- a/src/neurosdk.c
+++ b/src/neurosdk.c
@@ -513,8 +513,11 @@ NEUROSDK_EXPORT neurosdk_error_e neurosdk_context_create(
     goto cleanup2;
   }
 
+  struct mg_str host = mg_url_host(fetched_url);
+  unsigned short port = mg_url_port(fetched_url);
   context->conn = mg_ws_connect(&context->mgr, fetched_url, connection_fn_,
-                                (void *)context, NULL);
+    (void *)context, "Host: %.*s:%u\r\n", (int)host.len, host.buf, port);
+
   if (!context->conn) {
     res = NeuroSDK_ConnectionError;
     goto cleanup3;


### PR DESCRIPTION
Mongoose, upon trying to upgrade from HTTP to WebSocket, doesn't include the port which invalidates the standard for WebSockets ([RFC 6455](https://datatracker.ietf.org/doc/html/rfc6455)). This means that there can be validation issues when trying to connect to a WebSocket server that strictly enforces the WebSocket standard.

This is a patch, which fixes this issue, making this SDK more in line with other SDKs for Neuro-sama.