### PR TITLE
Handle new Startup Acknowledgment message sent from the server

### DIFF
--- a/include/neurosdk.h
+++ b/include/neurosdk.h
@@ -82,7 +82,8 @@ typedef enum neurosdk_message_kind {
 	NeuroSDK_MessageKind_ActionsForce,
 	NeuroSDK_MessageKind_ActionResult,
 	// Server to Client (S2C)
-	NeuroSDK_MessageKind_Action
+	NeuroSDK_MessageKind_Action,
+	NeuroSDK_MessageKind_StartupResponse
 } neurosdk_message_kind_e;
 
 // Callbacks
@@ -143,6 +144,12 @@ typedef struct neurosdk_message_action {
 	char *data;
 } neurosdk_message_action_t;
 
+// Startup Response
+typedef struct neurosdk_message_startup_response {
+	char *command;
+	char *data;
+} neurosdk_message_startup_response_t;
+
 // General Message Structure
 typedef struct neurosdk_message {
 	neurosdk_message_kind_e kind;
@@ -153,6 +160,7 @@ typedef struct neurosdk_message {
 		neurosdk_message_actions_force_t actions_force;
 		neurosdk_message_action_result_t action_result;
 		neurosdk_message_action_t action;
+		neurosdk_message_startup_response_t startup_response;
 	} value;
 } neurosdk_message_t;
 
@@ -196,6 +204,12 @@ neurosdk_context_poll(neurosdk_context_t *ctx,
                       OUT int *count);
 NEUROSDK_EXPORT neurosdk_error_e neurosdk_context_send(neurosdk_context_t *ctx,
                                                        neurosdk_message_t *msg);
+
+// Character Information
+NEUROSDK_EXPORT char const *neurosdk_context_character_id(
+    neurosdk_context_t *ctx);
+NEUROSDK_EXPORT char const *neurosdk_context_character_display_name(
+    neurosdk_context_t *ctx);
 
 #ifdef __cplusplus
 }

--- a/include/neurosdk.h
+++ b/include/neurosdk.h
@@ -206,6 +206,8 @@ NEUROSDK_EXPORT neurosdk_error_e neurosdk_context_send(neurosdk_context_t *ctx,
                                                        neurosdk_message_t *msg);
 
 // Character Information
+NEUROSDK_EXPORT char const *neurosdk_context_session_id(
+    neurosdk_context_t *ctx);
 NEUROSDK_EXPORT char const *neurosdk_context_character_id(
     neurosdk_context_t *ctx);
 NEUROSDK_EXPORT char const *neurosdk_context_character_display_name(

--- a/src/neurosdk.c
+++ b/src/neurosdk.c
@@ -167,10 +167,6 @@ static char *escape_string(char const *str) {
 				*dst++ = '\\';
 				*dst++ = '\"';
 				break;
-			case '\'':
-				*dst++ = '\\';
-				*dst++ = '\'';
-				break;
 			default:
 				if ((unsigned char)*str < 32 || (unsigned char)*str > 126) {
 					dst += sprintf(dst, "\\x%02X", (unsigned char)*str);

--- a/src/neurosdk.c
+++ b/src/neurosdk.c
@@ -185,7 +185,7 @@ static char *escape_string(char const *str) {
 }
 
 #if defined(_MSC_VER)
-static int vasprintf(char **strp, const char *fmt, va_list ap) {
+static int vasprintf(char **strp, char const *fmt, va_list ap) {
 	va_list ap_copy;
 	int formattedLength, actualLength;
 	size_t requiredSize;
@@ -213,7 +213,7 @@ static int vasprintf(char **strp, const char *fmt, va_list ap) {
 }
 #endif
 
-static int aprintf(char **strp, const char *fmt, ...) {
+static int aprintf(char **strp, char const *fmt, ...) {
 	va_list args;
 	va_start(args, fmt);
 	int bytes = vasprintf(strp, fmt, args);
@@ -1060,6 +1060,14 @@ neurosdk_message_destroy(neurosdk_message_t *msg) {
 		return NeuroSDK_UnknownCommand;
 	}
 	return NeuroSDK_None;
+}
+
+NEUROSDK_EXPORT char const *neurosdk_context_session_id(
+    neurosdk_context_t *ctx) {
+	if (!ctx || !(*ctx)) {
+		return NULL;
+	}
+	return ((context_t *)*ctx)->session_id;
 }
 
 NEUROSDK_EXPORT char const *neurosdk_context_character_id(

--- a/src/neurosdk.c
+++ b/src/neurosdk.c
@@ -133,6 +133,10 @@ typedef struct context {
 
 	bool debug_prints : 1;
 	bool validation_layers : 1;
+
+	char *session_id;
+	char *character_id;
+	char *character_display_name;
 } context_t;
 
 static char *escape_string(char const *str) {
@@ -299,6 +303,8 @@ static neurosdk_error_e parse_s2c_json(context_t *ctx,
 
 			if (!strcmp(value_str->string, "action")) {
 				kind = NeuroSDK_MessageKind_Action;
+			} else if (!strcmp(value_str->string, "startup")) {
+				kind = NeuroSDK_MessageKind_StartupResponse;
 			} else {
 				LOG_ERROR(ctx, "[parse_s2c_json] Unknown command '%s'.",
 				          value_str->string);
@@ -315,7 +321,77 @@ static neurosdk_error_e parse_s2c_json(context_t *ctx,
 		goto cleanup;
 	}
 
-	if (kind == NeuroSDK_MessageKind_Action) {
+	if (kind == NeuroSDK_MessageKind_StartupResponse) {
+		msg->kind = NeuroSDK_MessageKind_StartupResponse;
+		root_elem = root_obj->start;
+		while (root_elem) {
+			if (!strcmp(root_elem->name->string, "data")) {
+				if (root_elem->value->type != json_type_object) {
+					LOG_ERROR(ctx, "[parse_s2c_json] 'data' field is not an object.");
+					res = NeuroSDK_InvalidJSON;
+					goto cleanup;
+				}
+				json_object_t *data_obj = (json_object_t *)root_elem->value->payload;
+				json_object_element_t *obj_root = data_obj->start;
+
+				while (obj_root) {
+					if (!strcmp(obj_root->name->string, "session")) {
+						if (obj_root->value->type != json_type_object) {
+							LOG_ERROR(ctx,
+							          "[parse_s2c_json] 'session' field is not an object.");
+							res = NeuroSDK_InvalidJSON;
+							goto cleanup;
+						}
+						json_object_t *session_obj =
+						    (json_object_t *)obj_root->value->payload;
+						json_object_element_t *session_elem = session_obj->start;
+
+						while (session_elem) {
+							if (!strcmp(session_elem->name->string, "sessionId")) {
+								if (session_elem->value->type != json_type_string) {
+									LOG_ERROR(
+									    ctx,
+									    "[parse_s2c_json] 'sessionId' field is not a string.");
+									res = NeuroSDK_InvalidJSON;
+									goto cleanup;
+								}
+								json_string_t *str =
+								    (json_string_t *)session_elem->value->payload;
+								ctx->session_id = strdup(str->string);
+							} else if (!strcmp(session_elem->name->string, "characterId")) {
+								if (session_elem->value->type != json_type_string) {
+									LOG_ERROR(
+									    ctx,
+									    "[parse_s2c_json] 'characterId' field is not a string.");
+									res = NeuroSDK_InvalidJSON;
+									goto cleanup;
+								}
+								json_string_t *str =
+								    (json_string_t *)session_elem->value->payload;
+								ctx->character_id = strdup(str->string);
+							} else if (!strcmp(session_elem->name->string, "displayName")) {
+								if (session_elem->value->type != json_type_string) {
+									LOG_ERROR(
+									    ctx,
+									    "[parse_s2c_json] 'displayName' field is not a string.");
+									res = NeuroSDK_InvalidJSON;
+									goto cleanup;
+								}
+								json_string_t *str =
+								    (json_string_t *)session_elem->value->payload;
+								ctx->character_display_name = strdup(str->string);
+							}
+							session_elem = session_elem->next;
+						}
+					}
+					obj_root = obj_root->next;
+				}
+			}
+			root_elem = root_elem->next;
+		}
+
+		goto cleanup;
+	} else if (kind == NeuroSDK_MessageKind_Action) {
 		root_elem = root_obj->start;
 		while (root_elem) {
 			if (!strcmp(root_elem->name->string, "data")) {
@@ -984,6 +1060,21 @@ neurosdk_message_destroy(neurosdk_message_t *msg) {
 		return NeuroSDK_UnknownCommand;
 	}
 	return NeuroSDK_None;
+}
+
+NEUROSDK_EXPORT char const *neurosdk_context_character_id(
+    neurosdk_context_t *ctx) {
+	if (!ctx || !(*ctx)) {
+		return NULL;
+	}
+	return ((context_t *)*ctx)->character_id;
+}
+NEUROSDK_EXPORT char const *neurosdk_context_character_display_name(
+    neurosdk_context_t *ctx) {
+	if (!ctx || !(*ctx)) {
+		return NULL;
+	}
+	return ((context_t *)*ctx)->character_display_name;
 }
 
 #include "mongoose.c"


### PR DESCRIPTION
Hi,

hope the changes here are good, i'm not a expert at C so i might have done things suboptimal but i tried my best at adhering to existing patterns when handling the new startup acknowledgement message.

I tested these changes with Gary and seems to work great.
These changes also include a issue i encountered where the sdk would sent malformed json if the context sent contained a single ' quote.
Its unclear to me why it was escaped in the first place since it should be valid json without escaping, so i removed it and the issue went away. I couldn't find a explanation in the gitlog to why it was added maybe there was a valid reason but so far i didn't run into a issue with it removed. 

i've exposed character_id, character_display_name and also session_id. 
SessionId shouldn't be needed by clients and the official sdk's seem to just discard the value, but maybe it could be useful.. Shouldn't hurt to just store it just in case.