### PR TITLE
Action result command should be action/result not action:result

### DIFF
--- a/src/neurosdk.c
+++ b/src/neurosdk.c
@@ -998,7 +998,7 @@ neurosdk_context_send(neurosdk_context_t *ctx, neurosdk_message_t *msg) {
 
 			bytes =
 			    aprintf(&str,
-			            "{\"command\":\"action:result\",\"game\":\"%s\",\"data\":{"
+			            "{\"command\":\"action/result\",\"game\":\"%s\",\"data\":{"
 			            "\"id\":\"%s\",\"success\":%s,\"message\":%s}}",
 			            context->game_name, msg->value.action_result.id,
 			            msg->value.action_result.success ? "true" : "false", message);


### PR DESCRIPTION
this is the correct command representation according to the sdk api [Specification](https://github.com/VedalAI/neuro-sdk/blob/2f0f8a7e8a8e228db98355e45b1767649bf87bb4/API/SPECIFICATION.md?plain=1#L172)

I'm unsure where the action:result came from? as the other commands are properly written to spec but this was a outlier and according to the git blame it has always been action/result.